### PR TITLE
feat: go and jet renderer engine for framework

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,3 +25,5 @@ test\:mux:
 	@go test ./mux
 test\:session:
 	@go test ./session
+test\:render:
+	@go test ./render

--- a/go.mod
+++ b/go.mod
@@ -37,6 +37,7 @@ require (
 	github.com/gorilla/mux v1.8.0 // indirect
 	github.com/joho/godotenv v1.5.1 // indirect
 	github.com/json-iterator/go v1.1.10 // indirect
+	github.com/justinas/nosurf v1.2.0 // indirect
 	github.com/klauspost/cpuid/v2 v2.2.10 // indirect
 	github.com/mailgun/mailgun-go/v4 v4.4.1 // indirect
 	github.com/moby/docker-image-spec v1.3.1 // indirect
@@ -48,6 +49,7 @@ require (
 	github.com/opencontainers/image-spec v1.1.0 // indirect
 	github.com/opencontainers/runc v1.2.3 // indirect
 	github.com/ory/dockertest/v3 v3.12.0 // indirect
+	github.com/petaki/inertia-go v1.5.0 // indirect
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/sendgrid/rest v2.6.3+incompatible // indirect
 	github.com/sendgrid/sendgrid-go v3.8.0+incompatible // indirect

--- a/go.sum
+++ b/go.sum
@@ -80,6 +80,8 @@ github.com/joho/godotenv v1.5.1 h1:7eLL/+HRGLY0ldzfGMeQkb7vMd0as4CfYvUVzLqw0N0=
 github.com/joho/godotenv v1.5.1/go.mod h1:f4LDr5Voq0i2e/R5DDNOoa2zzDfwtkZa6DnEwAbqwq4=
 github.com/json-iterator/go v1.1.10 h1:Kz6Cvnvv2wGdaG/V8yMvfkmNiXq9Ya2KUv4rouJJr68=
 github.com/json-iterator/go v1.1.10/go.mod h1:KdQUCv79m/52Kvf8AW2vK1V8akMuk1QjK/uOdHXbAo4=
+github.com/justinas/nosurf v1.2.0 h1:yMs1bSRrNiwXk4AS6n8vL2Ssgpb9CB25T/4xrixaK0s=
+github.com/justinas/nosurf v1.2.0/go.mod h1:ALpWdSbuNGy2lZWtyXdjkYv4edL23oSEgfBT1gPJ5BQ=
 github.com/kisielk/errcheck v1.5.0/go.mod h1:pFxgyoBC7bSaBwPgfKdkLd5X25qrDl4LWUI2bnpBCr8=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
 github.com/klauspost/cpuid/v2 v2.2.10 h1:tBs3QSyvjDyFTq3uoc/9xFpCuOsJQFNPiAhYdw2skhE=
@@ -108,6 +110,8 @@ github.com/opencontainers/runc v1.2.3 h1:fxE7amCzfZflJO2lHXf4y/y8M1BoAqp+FVmG19o
 github.com/opencontainers/runc v1.2.3/go.mod h1:nSxcWUydXrsBZVYNSkTjoQ/N6rcyTtn+1SD5D4+kRIM=
 github.com/ory/dockertest/v3 v3.12.0 h1:3oV9d0sDzlSQfHtIaB5k6ghUCVMVLpAY8hwrqoCyRCw=
 github.com/ory/dockertest/v3 v3.12.0/go.mod h1:aKNDTva3cp8dwOWwb9cWuX84aH5akkxXRvO7KCwWVjE=
+github.com/petaki/inertia-go v1.5.0 h1:ab5iyBVdAAMIHvAhTOG5UTCIkYnJQ/SuIFiKQm6eDYU=
+github.com/petaki/inertia-go v1.5.0/go.mod h1:0oATJU1bvDxYjCDE2Sms4j33hdMqePlpZ3cAIUvzPeA=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
 github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=

--- a/helpers.go
+++ b/helpers.go
@@ -36,3 +36,11 @@ func (a *Adele) CreateFileIfNotExist(path string) error {
 	}
 	return nil
 }
+
+// Get environment variable or return default if the value is an empty string.
+func Getenv(key, defaultValue string) string {
+	if value := os.Getenv(key); value != "" {
+		return value
+	}
+	return defaultValue
+}

--- a/render/render.go
+++ b/render/render.go
@@ -1,0 +1,147 @@
+package render
+
+import (
+	"errors"
+	"fmt"
+	"html/template"
+	"log"
+	"net/http"
+	"strings"
+
+	"github.com/CloudyKit/jet/v6"
+	"github.com/alexedwards/scs/v2"
+	"github.com/justinas/nosurf"
+	"github.com/petaki/inertia-go"
+)
+
+type Render struct {
+	Renderer       string
+	RootPath       string
+	Directory      string
+	Secure         bool
+	Port           string
+	ServerName     string
+	JetViews       *jet.Set
+	Session        *scs.SessionManager
+	InertiaManager *inertia.Inertia
+}
+
+type TemplateData struct {
+	IsAuthenticated bool
+	IntMap          map[string]int
+	StringMap       map[string]string
+	FloatMap        map[string]float32
+	Data            map[string]interface{} // Use interface data can be anything.
+	CSRFToken       string
+	Port            string
+	ServerName      string
+	Secure          bool
+	Error           string
+	Flash           string
+}
+
+func (a *Render) defaultData(td *TemplateData, r *http.Request) *TemplateData {
+	td.Secure = a.Secure
+	td.ServerName = a.ServerName
+	td.Port = a.Port
+	td.CSRFToken = nosurf.Token(r)
+
+	if a.Session.Exists(r.Context(), "userID") {
+		td.IsAuthenticated = true
+	}
+
+	td.Error = a.Session.PopString(r.Context(), "error")
+	td.Flash = a.Session.PopString(r.Context(), "flash")
+	return td
+}
+
+func (a *Render) Page(w http.ResponseWriter, r *http.Request, view string, variables, data interface{}) error {
+	switch strings.ToLower(a.Renderer) {
+	case "go":
+		return a.GoPage(w, r, view, data)
+	case "jet":
+		return a.JetPage(w, r, view, variables, data)
+	default:
+	}
+	return errors.New("no rendering engine provided")
+}
+
+// Render with Inertia
+func (a *Render) InertiaPage(w http.ResponseWriter, r *http.Request, template string) error {
+
+	csrfToken := nosurf.Token(r)
+	ctx := a.InertiaManager.WithViewData(r.Context(), "csrf", csrfToken)
+	r = r.WithContext(ctx)
+
+	flash := a.Session.Pop(r.Context(), "flash")
+
+	err := a.InertiaManager.Render(w, r, template, map[string]interface{}{
+		"flash": flash,
+		"csrf":  csrfToken,
+	})
+	if err != nil {
+		log.Printf(fmt.Sprintf("%s", err))
+		return err
+	}
+
+	return nil
+}
+
+// Render with standard go templates
+func (a *Render) GoPage(w http.ResponseWriter, r *http.Request, view string, data interface{}) error {
+	tmpl, err := template.ParseFiles(fmt.Sprintf("%s/%s/%s.page.tmpl", a.RootPath, a.Directory, view))
+	if err != nil {
+		return err
+	}
+
+	td := &TemplateData{}
+	if data != nil {
+		td = data.(*TemplateData) // cast it
+	}
+
+	err = tmpl.Execute(w, &td)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// Render with Jet templates
+func (a *Render) JetPage(w http.ResponseWriter, r *http.Request, templateName string, variables, data interface{}) error {
+	// To render templates Jet needs this to pass data to the templates
+	var vars jet.VarMap
+
+	// Convert the vars and data into the right format
+	if variables == nil {
+		vars = make(jet.VarMap)
+	} else {
+		vars = variables.(jet.VarMap) // cast it
+	}
+
+	td := &TemplateData{}
+	if data != nil {
+		td = data.(*TemplateData) // cast it, again
+	}
+
+	td = a.defaultData(td, r) // Add default data
+
+	// Now, render the templates
+	fmt.Println("=====>")
+	fmt.Println("Printer Name:", "JetViews", ", Type:", a.JetViews)
+
+	fmt.Println(fmt.Sprintf("%s.jet", templateName))
+	t, err := a.JetViews.GetTemplate(fmt.Sprintf("%s.jet", templateName))
+
+	if err != nil {
+		log.Printf(fmt.Sprintf("%s", err))
+		return err
+	}
+
+	if err = t.Execute(w, vars, td); err != nil {
+		log.Printf(fmt.Sprintf("%s", err))
+		return err
+	}
+
+	return nil
+}

--- a/render/render_test.go
+++ b/render/render_test.go
@@ -1,0 +1,109 @@
+package render
+
+import (
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/cidekar/adele-framework/mux"
+)
+
+var pageData = []struct {
+	name          string
+	renderer      string
+	template      string
+	errorExpected bool
+	errorMessage  string
+}{
+	{"go_page", "go", "home", false, "error rendering go template"},
+	{"go_page_no_template", "go", "no-file", true, "no error rendering non-existent go template, when on is expected"},
+	{"jet_page", "jet", "home", false, "error rendering jet template"},
+	{"jet_page_no_template", "jet", "no-file", true, "no error rendering non-existent jet template, when on is expected"},
+	{"invalid_renderer_engine", "foo", "home", true, "no error rendering with non-existent template engine"},
+}
+
+func TestRender_Page(t *testing.T) {
+
+	r := mux.NewRouter()
+
+	r.Use(testRenderer.Session.LoadAndSave)
+
+	for _, e := range pageData {
+
+		testRenderer.Renderer = e.renderer
+
+		r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+
+			err := testRenderer.Page(w, r, e.template, nil, nil)
+
+			if e.errorExpected {
+				if err == nil { // expect error
+					t.Errorf("%s: %s:", e.name, e.errorMessage)
+				}
+			} else {
+				if err != nil { // not expecting error
+					t.Errorf("%s: %s: %s:", e.name, e.errorMessage, err.Error())
+				}
+			}
+		})
+
+		// If we don't expect an error, execute the request.
+		if e.errorExpected != true {
+			ts := httptest.NewServer(r)
+			defer ts.Close()
+
+			_, body := makeRequest(t, ts, "GET", "/", nil)
+			if body != "Adel, let's build something." {
+				t.Fatalf("%s", body)
+			}
+
+		}
+
+	}
+}
+
+func TestRender_GoPage(t *testing.T) {
+
+	testRenderer.Renderer = "go"
+
+	r := mux.NewRouter()
+
+	r.Use(testRenderer.Session.LoadAndSave)
+
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		err := testRenderer.Page(w, r, "home", nil, nil)
+		if err != nil {
+			t.Error("Error rendering page", err)
+		}
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	if _, body := makeRequest(t, ts, "GET", "/", nil); body != "Adel, let's build something." {
+		t.Fatalf("%s", body)
+	}
+}
+
+func TestRender_JetPage(t *testing.T) {
+
+	testRenderer.Renderer = "jet"
+
+	r := mux.NewRouter()
+
+	r.Use(testRenderer.Session.LoadAndSave)
+
+	r.Get("/", func(w http.ResponseWriter, r *http.Request) {
+		err := testRenderer.Page(w, r, "home", nil, nil)
+		if err != nil {
+			t.Error("Error rendering page", err)
+		}
+	})
+
+	ts := httptest.NewServer(r)
+	defer ts.Close()
+
+	if _, body := makeRequest(t, ts, "GET", "/", nil); body != "Adel, let's build something." {
+		t.Fatalf("%s", body)
+	}
+}

--- a/render/setup_test.go
+++ b/render/setup_test.go
@@ -1,0 +1,61 @@
+package render
+
+import (
+	"io"
+	"io/ioutil"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"testing"
+
+	"github.com/CloudyKit/jet/v6"
+	"github.com/cidekar/adele-framework/session"
+)
+
+var views = jet.NewSet(
+	jet.NewOSFileSystemLoader("./testdata/views"),
+	jet.InDevelopmentMode(),
+)
+
+var sess = session.Session{
+	CookieLifetime: "1",
+	CookiePersist:  "true",
+	CookieName:     "adele",
+	CookieDomain:   "localhost",
+	SessionType:    "cookie",
+}
+
+var testRenderer = Render{
+	Directory: "views",
+	Renderer:  "",
+	RootPath:  "./testdata",
+	JetViews:  views,
+	Session:   sess.InitSession(),
+}
+
+func TestMain(m *testing.M) {
+	os.Exit(m.Run())
+}
+
+func makeRequest(t *testing.T, ts *httptest.Server, method, path string, body io.Reader) (*http.Response, string) {
+	req, err := http.NewRequest(method, ts.URL+path, body)
+	if err != nil {
+		t.Fatal(err)
+		return nil, ""
+	}
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatal(err)
+		return nil, ""
+	}
+
+	respBody, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatal(err)
+		return nil, ""
+	}
+	defer resp.Body.Close()
+
+	return resp, string(respBody)
+}

--- a/render/testdata/views/home.jet
+++ b/render/testdata/views/home.jet
@@ -1,0 +1,1 @@
+Adel, let's build something.

--- a/render/testdata/views/home.page.tmpl
+++ b/render/testdata/views/home.page.tmpl
@@ -1,0 +1,1 @@
+Adel, let's build something.

--- a/types.go
+++ b/types.go
@@ -1,28 +1,34 @@
 package adele
 
 import (
+	"github.com/CloudyKit/jet/v6"
 	"github.com/alexedwards/scs/v2"
 	"github.com/cidekar/adele-framework/mailer"
 	"github.com/cidekar/adele-framework/middleware"
 	"github.com/cidekar/adele-framework/mux"
+	"github.com/cidekar/adele-framework/render"
 	"github.com/sirupsen/logrus"
 )
 
 type Adele struct {
-	AppName         string
-	config          config
-	Debug           bool
-	Log             *logrus.Logger
-	Mail            mailer.Mail
-	middleware      middleware.Middleware
-	MaintenanceMode bool
-	Routes          *mux.Mux
-	RootPath        string
-	Session         *scs.SessionManager
-	Version         string
+	AppName          string
+	config           config
+	Debug            bool
+	JetViews         *jet.Set
+	Log              *logrus.Logger
+	Mail             mailer.Mail
+	middleware       middleware.Middleware
+	MaintenanceMode  bool
+	Render           *render.Render
+	Routes           *mux.Mux
+	RootPath         string
+	Session          *scs.SessionManager
+	Version          string
+	ViewsTemplateDir string
 }
 
 type config struct {
 	port        string
+	renderer    string
 	sessionType string
 }


### PR DESCRIPTION
# :meat_on_bone:  Summary
This PR introduces initial support for the renderer package in the Adele framework. The framework is designed to work out-of-the-box to render Go or Jet templates into HTML. The initial commit will support basic Go and Jet template functions with high hopes of helping developers hit the ground running with Adele. 

## :pencil2: Features - this update includes:
* **<b>Powerful Templating:**  Jet is a powerful templating library for Go. It provides a simple way to render dynamic content in HTML templates. 
* **Go Template:**  The built-in templating system provided by the Go programming language.
* **Simple Configuration:** Set VIEWS_TEMPLATE_DIR environment variable or use sensible defaults
* **Template Engine Selection:** Choose between Go templates or Jet via configuration
* **Layout Support:** Template inheritance and layout systems
* **Helper Functions:** Built-in template helpers for common tasks

### Additional Notes
This PR includes a new helper for getting environment variables, just like os.Getenv but a default value is allowed should the return contain an empty string.